### PR TITLE
URL Cleanup

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -7,7 +7,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+  https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/integration/ClientServerIntegrationTestsSupport.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/integration/ClientServerIntegrationTestsSupport.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/integration/ForkingClientServerIntegrationTestsSupport.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/integration/ForkingClientServerIntegrationTestsSupport.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/integration/IntegrationTestsSupport.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/integration/IntegrationTestsSupport.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/integration/SpringApplicationContextIntegrationTestsSupport.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/integration/SpringApplicationContextIntegrationTestsSupport.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/integration/SpringBootApplicationIntegrationTestsSupport.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/integration/SpringBootApplicationIntegrationTestsSupport.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/integration/config/ClientServerIntegrationTestsConfiguration.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/integration/config/ClientServerIntegrationTestsConfiguration.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/integration/config/SubscriptionEnabledClientServerIntegrationTestsConfiguration.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/integration/config/SubscriptionEnabledClientServerIntegrationTestsConfiguration.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/AsyncEventQueueMockObjects.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/AsyncEventQueueMockObjects.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/CacheMockObjects.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/CacheMockObjects.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/CacheServerMockObjects.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/CacheServerMockObjects.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/DiskStoreMockObjects.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/DiskStoreMockObjects.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/GatewayMockObjects.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/GatewayMockObjects.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/GemFireMockObjectsSupport.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/GemFireMockObjectsSupport.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/IndexMockObjects.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/IndexMockObjects.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/MockObjectsSupport.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/MockObjectsSupport.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/PoolMockObjects.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/PoolMockObjects.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/annotation/EnableGemFireMockObjects.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/annotation/EnableGemFireMockObjects.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/annotation/GemFireMockObjectsConfiguration.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/annotation/GemFireMockObjectsConfiguration.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/annotation/GemFireUnitTest.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/annotation/GemFireUnitTest.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/config/GemFireMockObjectsBeanPostProcessor.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/config/GemFireMockObjectsBeanPostProcessor.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/context/GemFireMockObjectsApplicationContextInitializer.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/context/GemFireMockObjectsApplicationContextInitializer.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/support/MockObjectInvocationException.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/support/MockObjectInvocationException.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/support/MockObjectsException.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/support/MockObjectsException.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/process/PidNotFoundException.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/process/PidNotFoundException.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/process/ProcessConfiguration.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/process/ProcessConfiguration.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/process/ProcessExecutor.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/process/ProcessExecutor.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/process/ProcessInputStreamListener.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/process/ProcessInputStreamListener.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/process/ProcessUtils.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/process/ProcessUtils.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/process/ProcessWrapper.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/process/ProcessWrapper.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/support/AbstractSecurityManager.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/support/AbstractSecurityManager.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/support/DataSourceAdapter.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/support/DataSourceAdapter.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/support/IdentifierSequence.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/support/IdentifierSequence.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/support/MapBuilder.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/support/MapBuilder.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/FileSystemUtils.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/FileSystemUtils.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/FileUtils.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/FileUtils.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/IOUtils.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/IOUtils.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/ObjectUtils.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/ObjectUtils.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/SocketUtils.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/SocketUtils.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/StackTraceUtils.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/StackTraceUtils.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/ThreadUtils.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/ThreadUtils.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/ThrowableUtils.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/ThrowableUtils.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/ZipUtils.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/util/ZipUtils.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/test/java/org/springframework/data/gemfire/MockClientCacheApplicationIntegrationTests.java
+++ b/spring-data-geode-test/src/test/java/org/springframework/data/gemfire/MockClientCacheApplicationIntegrationTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/test/java/org/springframework/data/gemfire/tests/mock/GemFireMockObjectsSupportIntegrationTests.java
+++ b/spring-data-geode-test/src/test/java/org/springframework/data/gemfire/tests/mock/GemFireMockObjectsSupportIntegrationTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-geode-test/src/test/java/org/springframework/data/gemfire/tests/mock/GemFireMockObjectsSupportUnitTests.java
+++ b/spring-data-geode-test/src/test/java/org/springframework/data/gemfire/tests/mock/GemFireMockObjectsSupportUnitTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 47 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).