### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,9 +4,9 @@ image:https://api.travis-ci.org/spring-projects/spring-boot-data-geode.svg?branc
 
 This project is a _Spring Data_ module building on the core _Spring Framework's_ `TestContext` used to
 write _Unit_ and _Integration Tests_ for both _Spring Data_ for https://pivotal.io/pivotal-gemfire[Pivotal GemFire]
-as well as _Spring Data_ for http://geode.apache.org/[Apache Geode].
+as well as _Spring Data_ for https://geode.apache.org/[Apache Geode].
 
-This project was born from http://projects.spring.io/spring-data-gemfire/[_Spring Data for Pivotal GemFire's_]
+This project was born from https://projects.spring.io/spring-data-gemfire/[_Spring Data for Pivotal GemFire's_]
 (https://github.com/spring-projects/spring-data-gemfire[GitHub project])
 https://github.com/spring-projects/spring-data-gemfire/tree/2.0.6.RELEASE/src/test/java/org/springframework/data/gemfire/test[test framework].
 This _test framework_ is used in SDG's test suite to test the proper function of Apache Geode or Pivotal GemFire

--- a/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/GemFireMockObjectsSupport.java
+++ b/spring-data-geode-test/src/main/java/org/springframework/data/gemfire/tests/mock/GemFireMockObjectsSupport.java
@@ -406,7 +406,7 @@ public abstract class GemFireMockObjectsSupport extends MockObjectsSupport {
 	 *
 	 * @param propertyName {@link String name} of the property to normalize.
 	 * @return the {@link String normalized form} of the Apache Geode/Pivotal GemFire System property.
-	 * @see <a href="http://geode.apache.org/docs/guide/16/reference/topics/gemfire_properties.html">GemFire Properties</a>
+	 * @see <a href="https://geode.apache.org/docs/guide/16/reference/topics/gemfire_properties.html">GemFire Properties</a>
 	 */
 	private static String normalizeGemFirePropertyName(String propertyName) {
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://geode.apache.org/ with 1 occurrences migrated to:  
  https://geode.apache.org/ ([https](https://geode.apache.org/) result 200).
* [ ] http://geode.apache.org/docs/guide/16/reference/topics/gemfire_properties.html with 1 occurrences migrated to:  
  https://geode.apache.org/docs/guide/16/reference/topics/gemfire_properties.html ([https](https://geode.apache.org/docs/guide/16/reference/topics/gemfire_properties.html) result 200).
* [ ] http://projects.spring.io/spring-data-gemfire/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-gemfire/ ([https](https://projects.spring.io/spring-data-gemfire/) result 200).